### PR TITLE
Upgrade to ruby-lsp 0.17.4 & add rubocop, add docker-compose.override.yml examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,35 @@
 FROM ruby:3.3.2-slim-bullseye
 MAINTAINER KasaHNO3 <umbrella.hsiao@gmail.com>
 
-# set timezone
+# Set timezone
 ARG TimeZone=Asia/Taipei
 RUN ln -snf /usr/share/zoneinfo/${TimeZone} /etc/localtime
 RUN echo ${TimeZone} > /etc/timezone
 
+# Install packages
 RUN apt-get update && apt-get install -y gcc make git vim
 # build-essential could provide better experience, while the installation is slow
 COPY ruby-extensions/Gemfile /usr/workspace/.devcontainer/ruby-extensions/Gemfile
 COPY ruby-extensions/Gemfile.lock /usr/workspace/.devcontainer/ruby-extensions/Gemfile.lock
 
+# Create a non-root user to use if preferred
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN groupadd --force --gid $USER_GID $USERNAME \
+  && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+  && mkdir -p /home/${USERNAME}/.vscode-server/extensions \
+  && mkdir -p /home/${USERNAME}/.vscode-server-insiders/extensions \
+  && chown -R ${USER_UID}:${USER_GID} /home/${USERNAME}/.vscode-server*
+
+# Install bundler
+ARG BUNDLER_VER=2.5.11
+
 WORKDIR /usr/workspace/.devcontainer/ruby-extensions
-RUN gem install bundler -v '2.5.11'
+RUN gem install bundler -v ${BUNDLER_VER}
 RUN bundle install
 
 WORKDIR /usr/workspace
 
-
+USER ${USERNAME}

--- a/docker-compose.override.more-examples.yml
+++ b/docker-compose.override.more-examples.yml
@@ -1,0 +1,19 @@
+services:
+  application:
+    build:
+      args:
+        # Set your timezone
+        TimeZone: Asia/Tokyo
+        # Create a non-root user to use if preferred
+        USERNAME: ${USER}
+        USER_UID: 1000 # run `id -u` in your host environment, and fill the id here
+        USER_GID: 1000 # run `id -g` in your host environment, and fill the id here
+    image: 'example-ruby2-lsp:latest'
+    container_name: example-ruby2-lsp
+    volumes:
+      # If you need git config
+      - ~/.gitconfig:/home/${USER}/.gitconfig:ro
+
+volumes:
+  vscode-extensions:
+    name: example-ruby2-lsp-vscode-extensions

--- a/docker-compose.override.simple-example.yml
+++ b/docker-compose.override.simple-example.yml
@@ -1,0 +1,8 @@
+services:
+  application:
+    image: simple-ruby2-lsp:latest
+    container_name: simple-ruby2-lsp
+
+volumes:
+  vscode-extensions:
+    name: simple-ruby2-lsp-vscode-extensions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - ..:/usr/workspace
       - vscode-extensions:/home/${USER}/.vscode-server/extensions
       - vscode-extensions:/home/${USER}/.vscode-server-insiders/extensions
-      # - ~/.gitconfig:/home/${USER}/.gitconfig:ro
     command: sleep infinity
 
 volumes:

--- a/ruby-extensions/Gemfile
+++ b/ruby-extensions/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 ruby '3.3.2'
 
-gem 'ruby-lsp'
+gem 'ruby-lsp', '~> 0.17.0'
+gem 'rubocop', '~> 1.64.0'

--- a/ruby-extensions/Gemfile.lock
+++ b/ruby-extensions/Gemfile.lock
@@ -1,20 +1,48 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
+    json (2.7.2)
     language_server-protocol (3.17.0.3)
+    parallel (1.25.1)
+    parser (3.3.3.0)
+      ast (~> 2.4.1)
+      racc
     prism (0.29.0)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.0)
+      strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     ruby-lsp (0.17.1)
       language_server-protocol (~> 3.17.0)
       prism (>= 0.29.0, < 0.30)
       sorbet-runtime (>= 0.5.10782)
+    ruby-progressbar (1.13.0)
     sorbet-runtime (0.5.11414)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   aarch64-linux
   ruby
 
 DEPENDENCIES
-  ruby-lsp
+  rubocop (~> 1.64.0)
+  ruby-lsp (~> 0.17.0)
 
 RUBY VERSION
    ruby 3.3.2p78


### PR DESCRIPTION
close #5 
close #6 (also add rubocop)

Tested in Ruby 2.7.0

(ruby-lsp. The Go to Definition feature for methods could give multiple candidates, but it's still more useful than the previous versions)
<img width="919" alt="image" src="https://github.com/umbrella-h/devcontainer-ruby2-lsp/assets/20543088/2ddec5cd-2942-45d0-ba11-2d25238c2f01">

(rubocop)
<img width="739" alt="image" src="https://github.com/umbrella-h/devcontainer-ruby2-lsp/assets/20543088/9c56df55-f4d0-4f1c-b887-f797ce4023af">
